### PR TITLE
Use bundled glydb data before falling back to GlyGen for GlyTouCan lookup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## New features
 
 * Add more glycans. Now the package contains 19,436 glycan structures, including non-intact glycans from GlyGen. (#9)
+* `glytoucan_to_struc()` now looks up accessions from `glydb_data` first and only falls back to the online GlyGen API for missing accessions. (#10)
 
 # glydb 0.5.0
 

--- a/R/glytoucan-to-struc.R
+++ b/R/glytoucan-to-struc.R
@@ -1,7 +1,8 @@
 #' Convert GlyTouCan Accessions to Glycan Structures
 #'
-#' Fetch GlyTouCan accessions from the GlyGen API and parse the returned IUPAC
-#' strings as [glyrepr::glycan_structure()] values.
+#' Look up GlyTouCan accessions from [glydb_data], then fetch missing
+#' accessions from the GlyGen API and parse the returned IUPAC strings as
+#' [glyrepr::glycan_structure()] values.
 #'
 #' @param glytoucan_ac A character vector of GlyTouCan accessions.
 #'
@@ -18,8 +19,14 @@ glytoucan_to_struc <- function(glytoucan_ac) {
     return(glyrepr::glycan_structure())
   }
 
-  details <- glygen_glycan_details(glytoucan_ac)
-  results <- purrr::map(details, glytoucan_detail_to_struc_safely)
+  results <- local_glytoucan_struc_results(glytoucan_ac)
+  missing <- purrr::map_lgl(results, is.null)
+
+  if (any(missing)) {
+    details <- glygen_glycan_details(glytoucan_ac[missing])
+    results[missing] <- purrr::map(details, glytoucan_detail_to_struc_safely)
+  }
+
   failed <- purrr::map_lgl(results, "failed")
 
   if (any(failed)) {
@@ -32,6 +39,28 @@ glytoucan_to_struc <- function(glytoucan_ac) {
 
   strucs <- purrr::map(results, "struc")
   vctrs::vec_c(!!!strucs)
+}
+
+#' Look up GlyTouCan accessions from glydb data
+#'
+#' Match GlyTouCan accessions to bundled `glydb_data` structures while
+#' preserving input order and unresolved positions.
+#'
+#' @param glytoucan_ac A character vector of GlyTouCan accessions.
+#'
+#' @returns A list of conversion result records or `NULL` for accessions that
+#'   are not available in `glydb_data`.
+#' @noRd
+local_glytoucan_struc_results <- function(glytoucan_ac) {
+  data_position <- match(glytoucan_ac, glydb_data$glytoucan_ac)
+
+  purrr::map(data_position, function(position) {
+    if (is.na(position)) {
+      return(NULL)
+    }
+
+    list(struc = glydb_data$glycan_structure[position], failed = FALSE)
+  })
 }
 
 #' Convert one GlyGen detail record to a glycan structure

--- a/man/glytoucan_to_struc.Rd
+++ b/man/glytoucan_to_struc.Rd
@@ -15,8 +15,9 @@ fetched or parsed are returned as \code{NA} values in their original positions,
 and a warning is emitted.
 }
 \description{
-Fetch GlyTouCan accessions from the GlyGen API and parse the returned IUPAC
-strings as \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} values.
+Look up GlyTouCan accessions from \link{glydb_data}, then fetch missing
+accessions from the GlyGen API and parse the returned IUPAC strings as
+\code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} values.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}

--- a/tests/testthat/test-glytoucan-to-struc.R
+++ b/tests/testthat/test-glytoucan-to-struc.R
@@ -68,6 +68,51 @@ test_that("glytoucan_to_struc performs GlyGen detail requests in parallel", {
   expect_equal(vctrs::vec_data(res), c("Man(a1-", "GlcNAc(b1-"))
 })
 
+test_that("glytoucan_to_struc uses glydb_data before GlyGen fallback", {
+  local_accession <- glydb_data$glytoucan_ac[[1]]
+  local_structure <- glydb_data$glycan_structure[1]
+  parallel_call_count <- 0L
+  request_urls <- character()
+
+  local_mocked_bindings(
+    req_perform_parallel = function(reqs, on_error, progress, ...) {
+      parallel_call_count <<- parallel_call_count + 1L
+      request_urls <<- purrr::map_chr(reqs, "url")
+
+      purrr::map(reqs, ~ glygen_test_response("alpha-D-Manp-(1->"))
+    },
+    .package = "httr2"
+  )
+
+  res <- glytoucan_to_struc(c("G00001AA", local_accession))
+
+  expect_equal(parallel_call_count, 1L)
+  expect_equal(
+    request_urls,
+    "https://api.glygen.org/glycan/detail/G00001AA/"
+  )
+  expect_equal(vctrs::vec_data(res[1]), "Man(a1-")
+  expect_equal(res[2], local_structure)
+})
+
+test_that("glytoucan_to_struc does not request accessions present in glydb_data", {
+  local_accessions <- glydb_data$glytoucan_ac[1:2]
+  parallel_call_count <- 0L
+
+  local_mocked_bindings(
+    req_perform_parallel = function(reqs, on_error, progress, ...) {
+      parallel_call_count <<- parallel_call_count + 1L
+      purrr::map(reqs, ~ glygen_test_response("alpha-D-Manp-(1->"))
+    },
+    .package = "httr2"
+  )
+
+  res <- glytoucan_to_struc(local_accessions)
+
+  expect_equal(parallel_call_count, 0L)
+  expect_equal(res, glydb_data$glycan_structure[1:2])
+})
+
 test_that("glytoucan_to_struc returns NA and warns for unparseable glycans", {
   local_mocked_bindings(
     req_perform_parallel = function(reqs, on_error, progress, ...) {


### PR DESCRIPTION
## Summary
- Look up GlyTouCan accessions in bundled `glydb_data` first and only call GlyGen for missing entries.
- Preserve input order while reducing unnecessary network requests.
- Add coverage for mixed local/remote resolution and all-local lookups.

## Testing
- Added unit tests for local-data precedence and skipped GlyGen requests when all accessions are already bundled.
- Existing conversion and warning behavior remains covered by the test suite.